### PR TITLE
Propose `retry` strategy for Events POST request

### DIFF
--- a/src/submitters/synchronizerEventsSubmitter.ts
+++ b/src/submitters/synchronizerEventsSubmitter.ts
@@ -3,6 +3,7 @@ import { ILogger } from '@splitsoftware/splitio-commons/src/logger/types';
 import { IPostEventsBulk } from '@splitsoftware/splitio-commons/src/services/types';
 import { StoredEventWithMetadata } from '@splitsoftware/splitio-commons/src/sync/submitters/types';
 import { IEventsCacheAsync } from '@splitsoftware/splitio-commons/types/storages/types';
+import { SplitIO } from '@splitsoftware/splitio-commons/types/types';
 import { groupByMetadata, metadataToHeaders } from './metadataUtils';
 
 /**
@@ -10,12 +11,36 @@ import { groupByMetadata, metadataToHeaders } from './metadataUtils';
  */
 const EVENTS_AMOUNT = 1000;
 /**
+ * Amount of attempts to retry a POST request action.
+ */
+const ATTEMPTS_NUMBER = 3;
+/**
  * Maximum number of bytes to be fetched from cache before posting to the backend.
  */
 const MAX_QUEUE_BYTE_SIZE = 5 * 1024 * 1024; // 5MB
 type ProcessedByMetadataEvents = {
   [metadataAsKey: string]: StoredEventWithMetadata[];
 };
+/**
+ * Retries a async function recursively n times.
+ *
+ * @param {Function}    fn       The function to attempt retry.
+ * @param {number}      retries  The amount of attempts to retries. Default 3.
+ * @param {string|null} err      A custom error message to display when error.
+ * @returns {Promise}
+ */
+function retry(
+  fn: () => any,
+  retries = 3,
+  err: string | null = null
+): Promise<any> {
+  if (retries === 0) {
+    return Promise.reject(err);
+  }
+  return fn().catch((err: string) => {
+    return retry(fn, (retries - 1), err);
+  });
+}
 /**
  * Function factory that will return an Event Submitter, that will be able to retrieve the
  * events from the Storage, process and group by Metadata and/or max bundle size, and finally push
@@ -32,6 +57,19 @@ export function eventsSubmitterFactory(
   logger: ILogger,
   // @todo: Add retry param.
 ): () => Promise<boolean> {
+  /**
+   * Function to wrap the POST requests and retries attempt.
+   *
+   * @param {SplitIO.EventData[]}    eventsQueue      List of Events in EventData type.
+   * @param {Record<string, string>} metadataHeaders  The Headers corresponding to Metadata.
+   */
+  async function tryPostEventsBulk(eventsQueue: SplitIO.EventData[], metadataHeaders: Record<string, string>) {
+    await retry(
+      () => postEventsBulk(JSON.stringify(eventsQueue), metadataHeaders),
+      ATTEMPTS_NUMBER
+    );
+  }
+
   return () => eventsCache.popNWithMetadata(EVENTS_AMOUNT)
     .then(async (events) => {
       const processedEvents: ProcessedByMetadataEvents = groupByMetadata(events, 'm');
@@ -48,16 +86,16 @@ export function eventsSubmitterFactory(
 
           // Case when the Queue size is already full.
           if ((eventsQueueSize + currentEventSize) > MAX_QUEUE_BYTE_SIZE) {
-            await postEventsBulk(JSON.stringify(eventsQueue), metadataToHeaders(currentEvent.m));
+            await tryPostEventsBulk(eventsQueue, metadataToHeaders(currentEvent.m));
             eventsQueue = [];
             eventsQueueSize = 0;
           }
           eventsQueue.push(currentEvent.e);
           eventsQueueSize += currentEventSize;
 
-          // Case when there are no more events to process and the queue has events to be sent.
+          // Case when there are no more events to process and the queue has events yet to be sent.
           if (currentMetadataEventsQueue.length === 0 && eventsQueue.length > 0) {
-            await postEventsBulk(JSON.stringify(eventsQueue), metadataToHeaders(currentEvent.m));
+            await tryPostEventsBulk(eventsQueue, metadataToHeaders(currentEvent.m));
           }
         }
       }


### PR DESCRIPTION
# Javascript Slim Synchronizer

## What did you accomplish?
In this PR, I'm proposing a retry strategy flow to retry `n` attempts to make the POST request to send **events** from the Storage to the Split's Events API.
This current implementation will try to make 3 attempts running the `postEventsBulk` action, and if the third fails the `submitter` task will return `false`.

## How do we test the changes introduced in this PR?
1 - Checkout this branch
`git checkout efant_eventsImpressions_retries`
2 - Run unit test
`npm run test:unit`

## Related JIRA tickets and PRs
[[Synchroniser] - Set retries strategy for Impressions/Events sync ](https://splitio.atlassian.net/browse/SDKS-2839)

## Extra Notes
Next steps: if this is ok, extract and refactor the `retry` function in order to implement it in within the Impressions submitter.
After that, I have to implement a recusively strategy to run the `submitter` until no elements are present in the storage.

@todo:
- [ ]  check if the default retries definition has some impact on the services.