### PR TITLE
CLI params & naming corrections/improvements

### DIFF
--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -18,20 +18,22 @@ const params = {
 };
 
 /**
- * Returning function with .
+ * Function to validate SDK settings and Synchronizer configs.
  *
  * @param {any} config  Object with the keys and values for instatiating a SettingsInternal object.
  * @returns {ISettingsInternal}
  */
 export function synchronizerSettingsValidator(config: any) {
-  const { eventsPerPost, maxRetries } = config.synchronizerConfigs;
+  let { eventsPerPost, maxRetries } = config.synchronizerConfigs;
 
-  if (isNaNNumber(eventsPerPost) || maxRetries <= 0 ) {
-    config.log.warn('EVENTS_PER_POST must be a positive integer number. Using default value instead.');
+  if (eventsPerPost && isNaNNumber(eventsPerPost) || eventsPerPost <= 0 ) {
+    console.log('EVENTS_PER_POST parameter must be a positive integer number. Using default value instead.');
+    config.synchronizerConfigs.eventsPerPost = undefined;
   }
 
-  if (isNaNNumber(maxRetries) || maxRetries <= 0 ) {
-    config.log.warn('MAX_RETRIES must be a positive integer number. Using default values instead.');
+  if (maxRetries && (isNaNNumber(maxRetries) || maxRetries <= 0) ) {
+    console.log('MAX_RETRIES parameter must be a positive integer number. Using default values instead.');
+    config.synchronizerConfigs.maxRetries = undefined;
   }
 
   return settingsValidation(config, params);


### PR DESCRIPTION
# Javascript Slim Synchronizer

## What did you accomplish?
In this PR, I'm adding a couple of improvements and naming corrections to some CLI params.
- Added validation for CLI params with options (`customRun`, `mode`, `impressionsMode`)
- Added support for some configs to be set from `env` or `json` file.

## How do we test the changes introduced in this PR?
1 - Checkout this branch
`git checkout efant_namingCorrections`
2 - Manually, build and run the app with some configs
Example using CLI params:
```
npm run build && clear && ./dist/cli.js -m <json|env> -k AN_APIKEY -s ./src/__tests__/customStorage/InMemoryStorage.js -r https://sdk.split-stage.io/api -e https://events.split-stage.io/api -p storagePrefix -c <splitsAndSegments|eventsAndImpressions>
```

## Related JIRA tickets and PRs
[[Synchroniser] - Check CLI params to match other Synchroniser naming convention](https://splitio.atlassian.net/browse/SDKS-2840)

## Extra Notes
Document where to track some changes.
https://docs.google.com/document/d/1-sS30hl7e62f7GKJaRZGzu-PmdvSX3KGYEePfJyolx4/edit