### PR TITLE
Refactor: moved settings validation into the Synchronizers class

### DIFF
--- a/e2e/synchronizer.test.ts
+++ b/e2e/synchronizer.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-magic-numbers */
 // @ts-nocheck
-import { Synchronizer, synchronizerSettingsValidator } from '../src/index';
+import { Synchronizer } from '../src/index';
 import { ICustomStorageWrapper }
   from '@splitsoftware/splitio-commons/src/storages/types';
 import { PREFIX, REDIS_PREFIX, REDIS_URL, SERVER_MOCK_URL } from './utils/constants';
@@ -23,7 +23,7 @@ const createSynchronizer = () => {
   /**
    * Settings creation.
    */
-  const settings = synchronizerSettingsValidator({
+  const settings = {
     core: {
       authorizationKey: 'fakeapikeyfortesting',
     },
@@ -44,7 +44,7 @@ const createSynchronizer = () => {
     logger: 'NONE',
     streamingEnabled: false,
     debug: true,
-  });
+  };
 
   return new Synchronizer(settings);
 };

--- a/src/Synchronizer.ts
+++ b/src/Synchronizer.ts
@@ -14,6 +14,8 @@ import ImpressionCountsCacheInMemory
   from '@splitsoftware/splitio-commons/src/storages/inMemory/ImpressionCountsCacheInMemory';
 import ImpressionObserver from '@splitsoftware/splitio-commons/src/trackers/impressionObserver/ImpressionObserver';
 import { ImpressionsCountSynchronizer } from './synchronizers/ImpressionsCountSynchronizer';
+import synchronizerSettingsValidator from './settings';
+import { validateApiKey } from '@splitsoftware/splitio-commons/src/utils/inputValidation';
 
 /**
  * Main class to handle the Synchronizer execution.
@@ -60,15 +62,20 @@ export default class Synchronizer {
    * @param  {ISettingsInternal} settings  Object containing the minimum settings required
    *                                       to instantiate the Manager.
    */
-  constructor(settings: ISettingsInternal) {
-    this._settings = settings;
+  constructor(settings: any) {
     this._observer = impressionObserverSSFactory();
+    const validatedSettings = synchronizerSettingsValidator(settings);
 
+    if (!validateApiKey(settings.log, settings.core.authorizationKey)) {
+      throw new Error('Unable to initialize Synchronizer task: invalid APIKEY.');
+    }
+
+    this._settings = validatedSettings;
     /**
      * The Split's HTTPclient, required to make the requests to the API.
      */
     this._splitApi = splitApiFactory(
-      settings,
+      this._settings,
       { getFetch: Synchronizer._getFetch },
     );
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,6 @@
 import fs from 'fs';
 import { exit, env, argv } from 'process';
-import { synchronizerSettingsValidator } from './';
 import { Synchronizer } from './';
-import { validateApiKey } from '@splitsoftware/splitio-commons/src/utils/inputValidation';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import dotenv from 'dotenv';
@@ -232,7 +230,7 @@ if (!_apikey) {
 /**
  * Settings creation.
  */
-const settings = synchronizerSettingsValidator({
+const settings = {
   core: {
     authorizationKey: _apikey,
   },
@@ -251,12 +249,8 @@ const settings = synchronizerSettingsValidator({
   },
   synchronizerConfigs,
   debug: debug || false,
-});
+};
 
-if (!validateApiKey(settings.log, _apikey)) {
-  console.log('Unable to initialize Synchronizer task: invalid APIKEY.');
-  exit(0);
-}
 
 const synchronizer = new Synchronizer(settings);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,1 @@
 export { default as Synchronizer } from './Synchronizer';
-export { default as synchronizerSettingsValidator } from './settings/index';


### PR DESCRIPTION
# Javascript Slim Synchronizer

## What did you accomplish?
I've refactored the Settings validation, which now takes place on the Synchronizer's class constructor.
Fixed tests too.

Now, instead of doing
```
import { Synchronizer, synchronizerSettingsValidator } from '@splitsoftware/splitio-node-slim-synchronizer'
// or using cjs
const { Synchronizer, synchronizerSettingsValidator } = require('@splitsoftware/splitio-node-slim-synchronizer')
```
You only need the `Synchronizer`
```
import { Synchronizer } from '@splitsoftware/splitio-node-slim-synchronizer'
// or using cjs
const { Synchronizer } = require('@splitsoftware/splitio-node-slim-synchronizer')
```
and execute the new method with the "raw" settings:
```

const settings = {
  core: {
    authorizationKey: '<A_VALID_STAGING_APIKEY>',
  },
 [...]
};

const _sync = new Synchronizer(settings);

```

## How do we test the changes introduced in this PR?
1 - Checkout this branch
`git checkout efant_refactor_settingsValidator`
2 - Run tests
(Having a Redis service up)
`npm run test:e2e:ci`

Or you can test like with the previous pr, by installing the `synchronizer` as a dependency in a local app and instantiate it.


## Related JIRA tickets and PRs
[[Synchronizer] - Refactor: move settings validation into the Synchronizer class](https://splitio.atlassian.net/browse/SDKS-3007)

## Extra Notes
