### PR TITLE
Added relative path management to storage param

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -137,7 +137,7 @@ const yargv = yargs(hideBin(argv))
       nargs: 1,
     },
   })
-  .config('json-file', (configPath) => JSON.parse(fs.readFileSync(configPath, 'utf-8')))
+  .config('config', (configPath) => JSON.parse(fs.readFileSync(configPath, 'utf-8')))
   .help('h')
   .alias('h', 'help')
   .epilog(`copyright ${new Date().getFullYear()}`)
@@ -231,10 +231,10 @@ switch (mode) {
 }
 
 try {
-  customStorage = require(_customStoragePath as string).default;
+  customStorage = require(`${process.cwd()}/${_customStoragePath}` as string).default;
 } catch (error) {
   // @ts-ignore
-  console.log('Error importing Storage', error.message);
+  console.log('Error importing Storage: ', error.message);
   exit(0);
 }
 


### PR DESCRIPTION
# Javascript Slim Synchronizer

## What did you accomplish?
I've added a small tweak to support relative path from the CLI. Usually, that's a [good practice](https://github.com/lirantal/nodejs-cli-apps-best-practices#72-use-relative-paths).
Also, i've fixed a small issue with json config file not being read and parsed to get the params.

## How do we test the changes introduced in this PR?
1 - Checkout this branch
`git checkout efant_pathResolution`
2 - Generate build and CLI
`npm run make:cli`
3 - Install package globally
`npm i -g ./`
4 - Test running the CLI
```
splitio-node-synchronizer -k <A_VALID_STAGING_APIKEY> -s relative/path/to/storage.js -r https://sdk.split-stage.io/api -e https://events.split-stage.io/api
```

## Related JIRA tickets and PRs
[[Synchronizer] - Improve path resolution ](https://splitio.atlassian.net/browse/SDKS-3006)

## Extra Notes
